### PR TITLE
Support 'null' origin

### DIFF
--- a/src/main/java/org/ebaysf/web/cors/CORSFilter.java
+++ b/src/main/java/org/ebaysf/web/cors/CORSFilter.java
@@ -607,7 +607,7 @@ public final class CORSFilter implements Filter {
         if (originHeader != null) {
             if (originHeader.isEmpty()) {
                 requestType = CORSRequestType.INVALID_CORS;
-            } else if (!isValidOrigin(originHeader)) {
+            } else if ("null".equals(originHeader) == false && !isValidOrigin(originHeader)) {
                 requestType = CORSRequestType.INVALID_CORS;
             } else {
                 String method = request.getMethod();


### PR DESCRIPTION
When using HTML which is deployed to a local hard drive, the browser will issue a CORS preflight request with an Origin header of "Origin: null".

Currently CORSFilter treats this as an invalid preflight request even if the filter is configured to allow origin "*". This pull request lets the filter allow this through.